### PR TITLE
Add student info survey with backend storage

### DIFF
--- a/backend/api/migrations/0004_studentprofile.py
+++ b/backend/api/migrations/0004_studentprofile.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('auth', '0001_initial'),
+        ('api', '0003_remove_readingpassage_questions_and_more'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='StudentProfile',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('grade', models.CharField(max_length=20)),
+                ('favorite_subject', models.CharField(blank=True, max_length=50)),
+                ('notes', models.TextField(blank=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='profile', to='auth.user')),
+            ],
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.contrib.auth.models import User
 
 class ReadingPassage(models.Model):
     genre = models.CharField(max_length=50, default="General")
@@ -22,3 +23,14 @@ class Question(models.Model):
 
     def __str__(self):
         return self.prompt or "(blank question)"
+
+
+class StudentProfile(models.Model):
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="profile")
+    grade = models.CharField(max_length=20)
+    favorite_subject = models.CharField(max_length=50, blank=True)
+    notes = models.TextField(blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return f"Profile for {self.user.username}"

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
-from .models import ReadingPassage, Question
+from django.contrib.auth.models import User
+from .models import ReadingPassage, Question, StudentProfile
 
 class QuestionSerializer(serializers.ModelSerializer):
     passage = serializers.SerializerMethodField()
@@ -18,3 +19,9 @@ class ReadingPassageSerializer(serializers.ModelSerializer):
     class Meta:
         model = ReadingPassage
         fields = '__all__'
+
+
+class StudentProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = StudentProfile
+        fields = ['grade', 'favorite_subject', 'notes']

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,5 +1,8 @@
 from django.urls import path
-from .views import next_question, reading_passage, generate_reading_question, get_reading, latest_reading, reading_quiz
+from .views import (
+    next_question, reading_passage, generate_reading_question, get_reading,
+    latest_reading, reading_quiz, register, student_info, student_question
+)
 
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
@@ -15,6 +18,9 @@ urlpatterns += [
   path('api/generate-question/', generate_reading_question, name='generate-question'),
   path("reading/latest/", latest_reading, name="latest-reading"),
   path("reading/quiz/", reading_quiz, name="reading-quiz"),
+  path("register", register, name="register"),
+  path("student-info", student_info, name="student-info"),
+  path("student-question", student_question, name="student-question"),
 
 
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -6,8 +6,9 @@ from django.conf import settings
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from .models import Question, ReadingPassage
-from .serializers import QuestionSerializer, ReadingPassageSerializer
+from django.contrib.auth.models import User
+from .models import Question, ReadingPassage, StudentProfile
+from .serializers import QuestionSerializer, ReadingPassageSerializer, StudentProfileSerializer
 from .reading import generate_reading_data, save_reading_to_db
 
 from openai import OpenAI
@@ -97,4 +98,55 @@ def reading_quiz(request):
     questions = Question.objects.filter(subject="Reading").order_by('?')[:5]
     serializer = QuestionSerializer(questions, many=True)
     return Response(serializer.data)
+
+
+@api_view(["POST"])
+def register(request):
+    data = request.data
+    username = data.get("username")
+    password = data.get("password")
+    email = data.get("email")
+    if not username or not password:
+        return Response({"success": False, "message": "Missing credentials"})
+    if User.objects.filter(username=username).exists():
+        return Response({"success": False, "message": "Username taken"})
+    user = User.objects.create_user(username=username, email=email, password=password)
+    return Response({"success": True, "message": "Registered", "user_id": user.id})
+
+
+@api_view(["POST"])
+def student_info(request):
+    if not request.user.is_authenticated:
+        return Response({"detail": "Authentication required"}, status=401)
+    serializer = StudentProfileSerializer(data=request.data)
+    if serializer.is_valid():
+        profile, _ = StudentProfile.objects.update_or_create(user=request.user, defaults=serializer.validated_data)
+        return Response({"success": True})
+    return Response(serializer.errors, status=400)
+
+
+def generate_student_question_text(profile):
+    prompt = (
+        f"Create a single short quiz question suitable for a student in grade {profile.grade}. "
+        f"Tailor it to the student's favourite subject {profile.favorite_subject}. "
+        "Provide four multiple choice options labeled A-D and indicate the correct letter. "
+        "Return ONLY JSON in the format: {\"question\":..., \"options\":[...], \"answer\":\"A\"}"
+    )
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}]
+    )
+    return response.choices[0].message.content.strip()
+
+
+@api_view(["GET"])
+def student_question(request):
+    if not request.user.is_authenticated:
+        return Response({"detail": "Authentication required"}, status=401)
+    try:
+        profile = request.user.profile
+    except StudentProfile.DoesNotExist:
+        return Response({"detail": "Profile missing"}, status=404)
+    result = generate_student_question_text(profile)
+    return Response({"question": result})
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import Profile from "./pages/Profile";
 import Evaluations from "./pages/Evaluations";
 import Reading from "./pages/Reading";
 import Spelling from "./pages/Spelling";
+import StudentInfo from "./pages/StudentInfo";
 
 export default function App() {
   return (
@@ -15,6 +16,7 @@ export default function App() {
       <Routes>
         <Route path="/login"           element={<Login />} />
         <Route path="/register"        element={<Register />} />
+        <Route path="/student-info"    element={<StudentInfo />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/subjects"        element={<Subjects />} />
         <Route path="/math"            element={<Math />} />

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -23,8 +23,8 @@ export default function Register() {
       .then(r => r.json())
       .then(data => {
         if (data.success) {
-          setMessage("Registered! Redirecting…");
-          setTimeout(() => navigate("/login"), 1000);
+          setMessage("Registered! Let's learn more about you...");
+          setTimeout(() => navigate("/student-info"), 1000);
         } else setMessage(data.message);
       });
   }

--- a/frontend/src/pages/StudentInfo.jsx
+++ b/frontend/src/pages/StudentInfo.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function StudentInfo() {
+  const [form, setForm] = useState({ grade: "", favorite_subject: "", notes: "" });
+  const [message, setMessage] = useState("");
+  const navigate = useNavigate();
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const token = localStorage.getItem("access_token");
+    fetch("/api/student-info", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(form),
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.success) {
+          navigate("/subjects");
+        } else {
+          setMessage("Error saving info");
+        }
+      });
+  };
+
+  return (
+    <div className="centered-page">
+      <h2>Tell us about yourself</h2>
+      {message && <p>{message}</p>}
+      <form onSubmit={handleSubmit}>
+        <input name="grade" placeholder="Grade" value={form.grade} onChange={handleChange} required />
+        <input name="favorite_subject" placeholder="Favourite Subject" value={form.favorite_subject} onChange={handleChange} />
+        <textarea name="notes" placeholder="Anything else" value={form.notes} onChange={handleChange} />
+        <button type="submit">Save</button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `StudentProfile` model
- create serializer for the profile
- expose registration, profile save, and student question API endpoints
- add React page to collect student info after registration
- hook up new page in router and redirect from Register
- include migration for profile table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68472110d874832bb635884f439f07ea